### PR TITLE
feat: 添加 macOS 平台支持

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,3 +34,6 @@ tauri-plugin-dialog = "2.6.0"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"
+


### PR DESCRIPTION
https://github.com/Yang-505/Trae-Account-Manager/issues/1

- 实现 macOS 平台的 Trae IDE 路径扫描和管理
- 添加 macOS 进程检测、关闭和启动功能
- 使用 IOPlatformUUID 获取 macOS 机器码
- 支持 osascript 优雅关闭应用
- 更新平台条件编译，优化错误提示

Changes:
- src-tauri/src/machine.rs: 添加 macOS 实现
- src-tauri/Cargo.toml: 依赖版本更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended platform support to macOS, enabling account management, IDE process control (launch, stop, and monitor status), and machine identifier management on macOS systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->